### PR TITLE
Time to bonus fix

### DIFF
--- a/PokeRoadie/PokeRoadieLogic.cs
+++ b/PokeRoadie/PokeRoadieLogic.cs
@@ -230,7 +230,8 @@ namespace PokeRoadie
                 }
                 else
                 {
-                    Logger.Write($"Time to Bonus: {new TimeSpan(_playerProfile.PlayerData.DailyBonus.NextDefenderBonusCollectTimestampMs - DateTime.UtcNow.ToUnixTime())}", LogLevel.None, ConsoleColor.White);
+                    TimeSpan timeToBonus = TimeSpan.FromMilliseconds(_playerProfile.PlayerData.DailyBonus.NextDefenderBonusCollectTimestampMs - DateTime.UtcNow.ToUnixTime());
+                    Logger.Write($"Time to Bonus: {timeToBonus.ToString(@"dd\.hh\:mm\:ss")}", LogLevel.None, ConsoleColor.White);
                 }
                 if (Client.Proxy != null)
                 {

--- a/PokeRoadie/PokeRoadieLogic.cs
+++ b/PokeRoadie/PokeRoadieLogic.cs
@@ -231,7 +231,7 @@ namespace PokeRoadie
                 else
                 {
                     TimeSpan timeToBonus = TimeSpan.FromMilliseconds(_playerProfile.PlayerData.DailyBonus.NextDefenderBonusCollectTimestampMs - DateTime.UtcNow.ToUnixTime());
-                    Logger.Write($"Time to Bonus: {timeToBonus.ToString(@"dd\.hh\:mm\:ss")}", LogLevel.None, ConsoleColor.White);
+                    Logger.Write($"Time to Bonus: {timeToBonus.ToString(@"hh\:mm\:ss")}", LogLevel.None, ConsoleColor.White);
                 }
                 if (Client.Proxy != null)
                 {


### PR DESCRIPTION
Time To Bonus is currently showing a low decimal number - this is the fix to show the correct hh:mm:ss until the defender bonus is available again.
